### PR TITLE
Update building policy bundle in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ The policy file located in the opa folder must be compiled after changes. This c
 It requires you have the OPA CLI installed.
 
 ```bash
-$ opa build --bundle ./opa --output ./bundles/policy.tar.gz
+$ opa build --bundle ./opa --output ./bundles/bundle.tar.gz
 ```
 


### PR DESCRIPTION
Update the destination file for the output of the `opa build` to be the same as the one that is used according to the docker-compose file.