### PR TITLE
Slightly change Create Patient

### DIFF
--- a/Hackathon_2024.10/1 Setup/Create Patient.bru
+++ b/Hackathon_2024.10/1 Setup/Create Patient.bru
@@ -13,10 +13,10 @@ post {
 body:json {
   {
               "resourceType": "Patient",
-                  "identifier": {
+                  "identifier": [{
                       "system": "http://fhir.nl/fhir/NamingSystem/bsn",
                       "value": "{{bsn}}"
-                  }
+                  }]
   }
 }
 


### PR DESCRIPTION
I noticed the following warning from the fhir service whenever the Create Patient script was being used:

> Found incorrect type for element identifier - Expected ARRAY and found OBJECT

This corresponds to the fhir specification for a patient: https://build.fhir.org/patient-definitions.html#Patient.identifier

So made the change to surround the existing identifier with `[]`