### PR TITLE
upgrade nuts-node version to 6.0.0-rc.6

### DIFF
--- a/config/node1/nuts.yaml
+++ b/config/node1/nuts.yaml
@@ -1,5 +1,6 @@
 strictmode: false
 url: http://localhost:5551
+didmethods: [web]
 http:
   public:
     address: :5551
@@ -8,7 +9,7 @@ http:
 auth:
   contractvalidators: [employeeid]
 vdr:
-  didmethods: [web]
+  didmethods: [web] # moved in 6.0.0-rc.6 release to didmethods (root config). left there since it does not impact node startup.
 discovery:
   server:
     ids: ["hackathon_v2024"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   nuts-node1:
-    image: nutsfoundation/nuts-node:6.0.0-rc.3
+    image: nutsfoundation/nuts-node:6.0.0-rc.6
 #    user: when running on linux, this must be set to the host user if the datadir is mounted ($USER:$USER or $UID:$UID depending on what env variables exist)
     ports:
       - 5551:5551


### PR DESCRIPTION
preparation just in case bug fixes released between rc.3-rc.6 are needed during the hackathon